### PR TITLE
In atreus-view, flip middle buttons to reflect row order

### DIFF
--- a/atreus.el
+++ b/atreus.el
@@ -115,8 +115,8 @@ With the prefix arg, uploads firmware to keyboard."
                               key)))
 
 (defun atreus-splice-layer (rows dead)
-  (let ((middles (list (nth 5 (nth 2 rows))
-                       (nth 5 (nth 3 rows)))))
+  (let ((middles (list (nth 5 (nth 3 rows))
+                       (nth 5 (nth 2 rows)))))
     (list (atreus-splice-row (nth 0 rows) dead)
           (atreus-splice-row (nth 1 rows) dead)
           (atreus-splice-row (nth 2 rows) dead)


### PR DESCRIPTION
Per [my comments on the forum](http://geekhack.org/index.php?topic=54759.msg1456989#msg1456989), I think this results in the middle (thumb) buttons being shown correctly when `atreus-view` is called. 
