### PR TITLE
Tweak makefile to delete atreus.hex on a make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ jsonlayout: atreus.el $(LAYOUT).json
 
 # remove build files
 clean:
-	-rm -f $(TARGET){,.hex} *.o
+	-rm -f $(TARGET) $(TARGET).hex *.o
 
 layout.h: $(LAYOUT_DEPENDS)
 	-cp -n layout_qwerty.h layout.h


### PR DESCRIPTION
On my system, a make clean wasn't removing atreus.hex, so this is a tweak to the relevant line in the Makefile.

(this pull request typed on my atreus!)