### PR TITLE
Change docs to reflect the new development location for avr tools on tacos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ the USB device for uploading firmware.
 
 On Mac OS X with Homebrew:
 
-    $ brew tap larsimmisch/avr
+    $ brew tap osx-cross/avr
     $ brew install avr-libc
     $ brew install avrdude
 


### PR DESCRIPTION
The repo has moved. Lets update the docs to save MacOS users a little extra work.