### PR TITLE
Fixed issue with number replacement in svg

### DIFF
--- a/atreus-layout-to-svg.sh
+++ b/atreus-layout-to-svg.sh
@@ -42,7 +42,7 @@ function rendercharacters {
   -e 's/shift0/)/' \
   -e 's/shiftTILDE/~/' \
   -e 's/shiftMINUS/_/' \
-  -e 's/shiftEQUALS/+/' \
+  -e 's/shiftEQUAL/+/' \
   -e 's/shiftBACKSLASH/|/' \
   -e 's/shiftLEFT_BRACE/{/' \
   -e 's/shiftRIGHT_BRACE/}/' \
@@ -109,12 +109,9 @@ do
       #cat "$layerfile" | sed -e "s/>$((j + 1))</>$key</" > "$layerfile"
       sed -i -e "s/>$((j + 1))</>$key</" "$layerfile"
     elif [[ "$platform" == 'Darwin' ]]; then
-      sed -i "" -e "s/>$((j + 1))</>$key</" "$layerfile"
+      sed -i "" -e "s/>x$((j + 1))x</>$key</" "$layerfile"
     fi
   done
   cat "$layerfile" >> "$htmlfile"
   rm "$layerfile"
 done
-
-
-

--- a/atreus-layout.svg
+++ b/atreus-layout.svg
@@ -792,7 +792,7 @@
          sodipodi:role="line"
          id="tspan3146"
          x="14.56534"
-         y="-517.3255">1</tspan></text>
+         y="-517.3255">x1x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -804,7 +804,7 @@
          sodipodi:role="line"
          id="tspan3150"
          x="88.62114"
-         y="-527.52594">2</tspan></text>
+         y="-527.52594">x2x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -816,7 +816,7 @@
          sodipodi:role="line"
          id="tspan3158"
          x="158.26537"
-         y="-547.51965">3</tspan></text>
+         y="-547.51965">x3x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -828,7 +828,7 @@
          sodipodi:role="line"
          id="tspan3162"
          x="225.38373"
-         y="-530.45331">4</tspan></text>
+         y="-530.45331">x4x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -840,7 +840,7 @@
          sodipodi:role="line"
          id="tspan3166"
          x="291.83234"
-         y="-509.65549">5</tspan></text>
+         y="-509.65549">x5x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -852,7 +852,7 @@
          sodipodi:role="line"
          id="tspan3170"
          x="605.09991"
-         y="-346.10605">6</tspan></text>
+         y="-346.10605">x6x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -864,7 +864,7 @@
          sodipodi:role="line"
          id="tspan3174"
          x="672.42798"
-         y="-369.46863">7</tspan></text>
+         y="-369.46863">x7x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -876,7 +876,7 @@
          sodipodi:role="line"
          id="tspan3178"
          x="740.34393"
-         y="-385.9317">8</tspan></text>
+         y="-385.9317">x8x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -888,7 +888,7 @@
          sodipodi:role="line"
          id="tspan3182"
          x="808.75702"
-         y="-369.36578">9</tspan></text>
+         y="-369.36578">x9x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -900,7 +900,7 @@
          sodipodi:role="line"
          id="tspan3186"
          x="869.59436"
-         y="-357.87778">10</tspan></text>
+         y="-357.87778">x10x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -912,7 +912,7 @@
          sodipodi:role="line"
          id="tspan3190"
          x="17.415464"
-         y="-450.70361">11</tspan></text>
+         y="-450.70361">x11x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -924,7 +924,7 @@
          sodipodi:role="line"
          id="tspan3194"
          x="84.542961"
-         y="-461.62531">12</tspan></text>
+         y="-461.62531">x12x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -936,7 +936,7 @@
          sodipodi:role="line"
          id="tspan3198"
          x="150.55559"
-         y="-479.1676">13</tspan></text>
+         y="-479.1676">x13x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -948,7 +948,7 @@
          sodipodi:role="line"
          id="tspan3202"
          x="216.58781"
-         y="-460.60345">14</tspan></text>
+         y="-460.60345">x14x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -960,7 +960,7 @@
          sodipodi:role="line"
          id="tspan3206"
          x="286.77539"
-         y="-439.06049">15</tspan></text>
+         y="-439.06049">x15x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -972,7 +972,7 @@
          sodipodi:role="line"
          id="tspan3210"
          x="600.78247"
-         y="-277.49927">16</tspan></text>
+         y="-277.49927">x16x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -984,7 +984,7 @@
          sodipodi:role="line"
          id="tspan3214"
          x="666.36078"
-         y="-301.19189">17</tspan></text>
+         y="-301.19189">x17x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -996,7 +996,7 @@
          sodipodi:role="line"
          id="tspan3218"
          x="733.32166"
-         y="-317.34689">18</tspan></text>
+         y="-317.34689">x18x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1008,7 +1008,7 @@
          sodipodi:role="line"
          id="tspan3222"
          x="802.3009"
-         y="-298.86661">19</tspan></text>
+         y="-298.86661">x19x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1020,7 +1020,7 @@
          sodipodi:role="line"
          id="tspan3226"
          x="869.45508"
-         y="-287.98618">20</tspan></text>
+         y="-287.98618">x20x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1032,7 +1032,7 @@
          sodipodi:role="line"
          id="tspan3230"
          x="16.873419"
-         y="-381.91928">21</tspan></text>
+         y="-381.91928">x21x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1044,7 +1044,7 @@
          sodipodi:role="line"
          id="tspan3234"
          x="82.71022"
-         y="-392.6113">22</tspan></text>
+         y="-392.6113">x22x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1056,7 +1056,7 @@
          sodipodi:role="line"
          id="tspan3238"
          x="150.75777"
-         y="-411.41537">23</tspan></text>
+         y="-411.41537">x23x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1068,7 +1068,7 @@
          sodipodi:role="line"
          id="tspan3242"
          x="218.93112"
-         y="-395.93976">24</tspan></text>
+         y="-395.93976">x24x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1080,7 +1080,7 @@
          sodipodi:role="line"
          id="tspan3246"
          x="287.88223"
-         y="-373.72729">25</tspan></text>
+         y="-373.72729">x25x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1092,7 +1092,7 @@
          sodipodi:role="line"
          id="tspan3250"
          x="356.82468"
-         y="-341.22937">37</tspan></text>
+         y="-341.22937">x37x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1104,7 +1104,7 @@
          sodipodi:role="line"
          id="tspan3254"
          x="600.20691"
-         y="-212.69276">27</tspan></text>
+         y="-212.69276">x27x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1116,7 +1116,7 @@
          sodipodi:role="line"
          id="tspan3258"
          x="666.52612"
-         y="-233.02228">28</tspan></text>
+         y="-233.02228">x28x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1128,7 +1128,7 @@
          sodipodi:role="line"
          id="tspan3262"
          x="734.90778"
-         y="-252.1209">29</tspan></text>
+         y="-252.1209">x29x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1140,7 +1140,7 @@
          sodipodi:role="line"
          id="tspan3266"
          x="801.18127"
-         y="-233.65073">30</tspan></text>
+         y="-233.65073">x30x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1152,7 +1152,7 @@
          sodipodi:role="line"
          id="tspan3270"
          x="869.72522"
-         y="-222.96465">31</tspan></text>
+         y="-222.96465">x31x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1164,7 +1164,7 @@
          sodipodi:role="line"
          id="tspan3274"
          x="16.58029"
-         y="-314.58499">32</tspan></text>
+         y="-314.58499">x32x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1176,7 +1176,7 @@
          sodipodi:role="line"
          id="tspan3278"
          x="81.459877"
-         y="-325.60886">33</tspan></text>
+         y="-325.60886">x33x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1188,7 +1188,7 @@
          sodipodi:role="line"
          id="tspan3282"
          x="147.96242"
-         y="-342.79507">34</tspan></text>
+         y="-342.79507">x34x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1200,7 +1200,7 @@
          sodipodi:role="line"
          id="tspan3286"
          x="216.11688"
-         y="-324.95923">35</tspan></text>
+         y="-324.95923">x35x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1212,7 +1212,7 @@
          sodipodi:role="line"
          id="tspan3290"
          x="286.76111"
-         y="-305.85455">36</tspan></text>
+         y="-305.85455">x36x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1224,7 +1224,7 @@
          sodipodi:role="line"
          id="tspan3294"
          x="529.25262"
-         y="-179.14476">26</tspan></text>
+         y="-179.14476">x26x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1236,7 +1236,7 @@
          sodipodi:role="line"
          id="tspan3298"
          x="598.15393"
-         y="-144.8425">38</tspan></text>
+         y="-144.8425">x38x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1248,7 +1248,7 @@
          sodipodi:role="line"
          id="tspan3302"
          x="666.71539"
-         y="-167.52135">39</tspan></text>
+         y="-167.52135">x39x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1260,7 +1260,7 @@
          sodipodi:role="line"
          id="tspan3306"
          x="736.31134"
-         y="-183.28331">40</tspan></text>
+         y="-183.28331">x40x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1272,7 +1272,7 @@
          sodipodi:role="line"
          id="tspan3310"
          x="800.91718"
-         y="-165.61649">41</tspan></text>
+         y="-165.61649">x41x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
@@ -1284,7 +1284,7 @@
          sodipodi:role="line"
          id="tspan3314"
          x="868.60559"
-         y="-155.05147">42</tspan></text>
+         y="-155.05147">x42x</tspan></text>
     <text
        xml:space="preserve"
        style="font-size:20px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"


### PR DESCRIPTION
If your layout contained some of the numbers before they occurred in the svg, they would later incorrectly get swapped again.

Here's a layout with the bug:
<img width="903" alt="screen shot 2015-08-14 at 10 17 32 am" src="https://cloud.githubusercontent.com/assets/6825/9275828/e584bada-426d-11e5-8755-780e88838375.png">

Here's a layout with the fix:
<img width="904" alt="screen shot 2015-08-14 at 10 17 15 am" src="https://cloud.githubusercontent.com/assets/6825/9275836/f100c700-426d-11e5-9256-c592114dfa8e.png">


Here's the example layout I used: 
```json
[[["Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"],
  ["A", "S", "D", "F", "G", "H", "J", "K", "L", "SEMICOLON"],
  ["Z", "X", "C", "V", "B", "ALT", "N", "M", "COMMA", "PERIOD", "SLASH"],
  ["ESC", "TAB", "GUI", "SHIFT", "BACKSPACE", "CTRL",
   "SPACE", "FN", "MINUS", "QUOTE", "ENTER"]],
 [[["shift", "1"], "7", "8", "9",
   ["shift", "BACKSLASH"], "PAGE_UP", ["shift", "2"], ["shift", "LEFT_BRACE"], ["shift", "RIGHT_BRACE"], ["shift", "8"]],
  [["shift", "3"], ["shift", "4"], ["shift", "9"], ["shift", "0"],
  "TILDE", "PAGE_DOWN", "4", "5", "6", ["shift", "EQUAL"]],
  [["shift", "5"], ["shift", "6"], "LEFT_BRACE", "RIGHT_BRACE", ["shift", "TILDE"],
   "ALT", ["shift", "7"], "1", "2", "3", "BACKSLASH"],
  [["function", 2], ["shift", "INSERT"], "GUI", "SHIFT", "BACKSPACE", "CTRL",
   "SPACE", "FN", "PERIOD", "0", "EQUAL"]],
 [["HOME", "UP", "END", "INSERT", "PAGE_UP", "UP", "F7", "F8", "F9", "F10"],
  ["LEFT", "DOWN", "RIGHT", "DELETE", "PAGE_DOWN", "DOWN", "F4", "F5", "F6", "F11"],
  ["", "", "", "", "", "ALT", "", "F1", "F2", "F3", "F12"],
  [["layer", 0], "", "GUI", "SHIFT", "BACKSPACE", "CTRL",
   "SPACE", "FN", "", "", ["reset"]]]]
```

I also fixed the replacement of shiftEQUAL with the =