### PR TITLE
Keycode overflow fix

### DIFF
--- a/atreus.c
+++ b/atreus.c
@@ -16,7 +16,7 @@ void reset(void);
 // set this for layer changes that need to persist beyond one cycle
 int current_layer_number = 0;
 // this gets reset every cycle
-int *current_layer;
+unsigned int *current_layer;
 
 #define ROW_COUNT 4
 #define COL_COUNT 11
@@ -136,7 +136,7 @@ void debounce(int passes_remaining) {
 
 void pre_invoke_functions() {
   for(int i = 0; i < pressed_count; i++) {
-    int keycode = current_layer[presses[i]];
+    unsigned int keycode = current_layer[presses[i]];
     if(keycode >= MIN_PRE_FUNCTION && keycode <= MAX_PRE_FUNCTION) {
       (layer_functions[keycode - MIN_PRE_FUNCTION])();
     }
@@ -147,7 +147,7 @@ void pre_invoke_functions() {
 void calculate_presses() {
   int usb_presses = 0;
   for(int i = 0; i < pressed_count; i++) {
-    int keycode = current_layer[presses[i]];
+    unsigned int keycode = current_layer[presses[i]];
     if(keycode >= MIN_FUNCTION && keycode <= MAX_FUNCTION) {
       // regular layout functions
       (layer_functions[keycode - MIN_FUNCTION])();


### PR DESCRIPTION
I ran into this issue when I was trying to assign keys in the layout using the GUI macro. It resulted in the "modifier plus keypress" section of calculate_presses to be skipped since the int would roll over into the negatives.

To recreate the bug add GUI(KEY_Q) or whatever to your layout and you'll see it doesn't result in the modifiers being sent correctly and you'll only get a q inserted.