### PR TITLE
Add missing key on bottom right row of colemak.json

### DIFF
--- a/colemak.json
+++ b/colemak.json
@@ -15,7 +15,7 @@
   ["LEFT", "DOWN", "RIGHT", "DELETE", "PAGE_DOWN", "DOWN", "F4", "F5", "F6", "F11"],
   ["", "", "", "", "", "ALT", "", "F1", "F2", "F3", "F12"],
   [["layer", 0], "", "GUI", "SHIFT", "BACKSPACE", "CTRL",
-   "SPACE", "FN", "", ["reset"]]]]
+   "SPACE", "FN", "", "", ["reset"]]]]
 
 /* colemak.json
 


### PR DESCRIPTION
The `colemak.json` file was missing a key on the bottom right row.