### PR TITLE
Add support for fn+shift to easily switch to layer 2

### DIFF
--- a/layout_common.h
+++ b/layout_common.h
@@ -31,6 +31,19 @@ void (*layer_functions[])(void) = {reset, activate_fn, layer_jump};
 void per_cycle() {
   if(fn_decay > 1) {
     current_layer = layers[1];
+
+    // This hack checks each pressed key to see if it is the left
+    // shift key. If the left shift is pressed (in combination with
+    // the fn key) we switch to layer 2 instead of 1, and remove the
+    // left shift from the list of pressed keys.
+    for(int i = 0; i < pressed_count; i++) {
+      unsigned int keycode = current_layer[presses[i]];
+      if(keycode == KEYBOARD_LEFT_SHIFT) {
+        presses[i] = 0;
+        current_layer = layers[2];
+      }
+    }
+
     fn_decay--;
   } else if(fn_decay == 1) {
     current_layer_number = layer_to_jump;


### PR DESCRIPTION
I was taking a look at #26, and thought that I would take a stab at it. This is just a draft for folks to consider, and really is a hack. Please provide feedback.

Pros: It seems to work. :smile: 
Cons: I do not currently offer a way to toggle this functionality on/off.

Basically, when `fn` is down, I check all of the detected pressed keys to see if any of them are the left shift. If I find that the left shift is pressed, I switch have fn switch to layer 2, rather than layer 1, and remove the depressed shift for the list of pressed keys. This would require that any keys on layer 1 that should respond to shift, now have their shifted version configured on layer 2.
